### PR TITLE
add upper bound to sbv

### DIFF
--- a/saw-core-sbv.cabal
+++ b/saw-core-sbv.cabal
@@ -20,7 +20,7 @@ library
     lens,
     mtl,
     saw-core,
-    sbv >= 7.0,
+    sbv >= 7.0 && < 8.0,
     transformers,
     vector
   hs-source-dirs: src


### PR DESCRIPTION
sbv just released version 8.0, which does not expose the `MonadReader`
instance for `Symbolic` when importing `Data.SBV.Dynamic`.  In the meantime,
an upper bound for sbv helps build tools such as stack pick an
appropriate version of sbv to build against.